### PR TITLE
Correctly handle shots with no sets

### DIFF
--- a/pipeline/pipe/h/hipfile/shot.py
+++ b/pipeline/pipe/h/hipfile/shot.py
@@ -123,7 +123,8 @@ class HShotFileManager(HFileManager):
                 layout = self._conn.get_env_by_stub(env_stub)
                 if layout and layout.path:
                     load_layer.parm("layout_path").set(f"$JOB/{layout.path}/main.usd")  # type: ignore[union-attr]
-                load_layers.append(load_layer)
+
+            load_layers.append(load_layer)
 
         # Merge load layers if there are multiple
         if len(load_layers) > 1:
@@ -132,8 +133,11 @@ class HShotFileManager(HFileManager):
             for idx, load_layer in enumerate(load_layers):
                 merge_node.setInput(idx, load_layer)
             input_node = merge_node
-        else:
+        elif load_layers:
             input_node = load_layers[0]
+        else:
+            input_node = stage.createNode("null")
+            input_node.setName("NO_ENVIRONMENT", unique_name=True)
 
         layer_break = stage.createNode("layerbreak")
         layer_break.setInput(0, input_node)

--- a/pipeline/pipe/struct/db.py
+++ b/pipeline/pipe/struct/db.py
@@ -196,12 +196,14 @@ class Sequence(SGEntity):
     code: str = field(on_setattr=attrs.setters.frozen)
     shots: list[ShotStub]
     set: Optional[EnvironmentStub] = field(
+        default=None,
         metadata={
             _SG_NAME: "sg_set",
             _STRUCT_HOOK: lambda e, _: EnvironmentStub.from_sg(e) if e else None,
-        }
+        },
     )
     sets: list[EnvironmentStub] = field(
+        factory=list,
         metadata={
             _SG_NAME: "sg_sets",
             _STRUCT_HOOK: lambda raw_sets, _: [
@@ -238,12 +240,14 @@ class Shot(SGEntity):
         }
     )
     set: Optional[EnvironmentStub] = field(
+        default=None,
         metadata={
             _SG_NAME: "sg_set",
             _STRUCT_HOOK: lambda e, _: EnvironmentStub.from_sg(e) if e else None,
-        }
+        },
     )
     sets: list[EnvironmentStub] = field(
+        factory=list,
         metadata={
             _SG_NAME: "sg_sets",
             _STRUCT_HOOK: lambda raw_sets, _: [


### PR DESCRIPTION
Shots with no sets work now. This is done by:
- Adding a default constructor for `sets` in the database
- Removing a tab that snuck in while I wasn't looking