### PR TITLE
Name component geometry nodes "main" by default

### DIFF
--- a/pipeline/pipe/h/nodelayouts.py
+++ b/pipeline/pipe/h/nodelayouts.py
@@ -79,6 +79,9 @@ def bobo_componentgeometry(kwargs: dict, parent: Optional[hou.Node] = None) -> h
     else:
         cgeo = loptoolutils.genericTool(kwargs, "componentgeometry")
 
+    # Rename to match publishing expectations.
+    cgeo.setName("main", unique_name=True)
+
     # Set up nodes inside of Component Geometry
     geo_sop = cgeo.node("./sopnet/geo")
     geo_sop.loadItemsFromFile(


### PR DESCRIPTION
FEEL FREE TO REJECT THIS CAUSE ITS TECHNICALLY A LITTLE JANK but

this will name the component geometry node "main" by default.

Bella says artists are usually using the main geometry variant. But if you know otherwise, REJECT