### PR TITLE
Replace LnD_Lookdev with Bobo_Lookdev in Bobo Component Builder

### DIFF
--- a/pipeline/pipe/h/nodelayouts.py
+++ b/pipeline/pipe/h/nodelayouts.py
@@ -141,7 +141,7 @@ def bobo_componentsetup(kwargs: dict) -> hou.Node:
     mtl = lnd_componentmaterial(kwargs, parent=p)
     lib = p.createNode("dbclark::main::Bobo_MatLib")
     cnf = p.createNode("sdm223::lnd_componentconfig")
-    ldv = p.createNode("sdm223::dev::LnD_Lookdev")
+    ldv = p.createNode("dbclark::dev::Bobo_Lookdev")
     env = p.createNode("fetch")
     out.setInput(0, cnf)
     out.setInput(1, env)


### PR DESCRIPTION
Noticed the Bobo component builder node network uses the Love and Gold lookdev node instead of the Bobo version. NGL I dont know the difference but it uses the bobo node now