### PR TITLE
Auto publish maya to houdini

### DIFF
--- a/pipeline/pipe/h/__init__.py
+++ b/pipeline/pipe/h/__init__.py
@@ -3,8 +3,11 @@ from . import hipfile
 from . import local
 from . import shading
 
+from .assetbuilder import build_component_package
+
 __all__ = [
     "hipfile",
     "local",
     "shading",
+    "build_component_package",
 ]

--- a/pipeline/pipe/h/assetbuilder.py
+++ b/pipeline/pipe/h/assetbuilder.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import shutil
+import sys
+from pathlib import Path
+
+import hou
+
+from pipe.h import nodelayouts
+
+log = logging.getLogger(__name__)
+
+
+def _configure_logging(level: str) -> None:
+    level_name = level.upper()
+    numeric_level = getattr(logging, level_name, None)
+    if not isinstance(numeric_level, int):
+        numeric_level = logging.INFO
+        log.warning("Unknown log level %s, defaulting to INFO", level)
+    logging.basicConfig(
+        level=numeric_level, format="[assetbuilder] %(levelname)s: %(message)s"
+    )
+
+
+def _set_parm(node: hou.Node, name: str, value) -> None:
+    parm = node.parm(name)
+    if parm is None:
+        log.warning("Parameter %s missing on %s", name, node.path())
+        return
+    parm.set(value)
+
+
+def _prepare_stage() -> hou.Node:
+    stage = hou.node("/stage")
+    if stage is None:
+        raise RuntimeError(
+            "Could not locate /stage context in the current Houdini session"
+        )
+    # type: ignore[union-attr]
+    for child in stage.children():
+        try:
+            child.destroy()
+        except hou.OperationFailed:
+            log.warning(
+                "Failed to destroy node %s while resetting /stage", child.path()
+            )
+
+    return stage
+
+
+def _configure_component_geometry(geo_node: hou.LopNode, usd_path: Path) -> None:
+    sopnet = geo_node.node("./sopnet/geo")
+    if sopnet is None:
+        raise RuntimeError("Component Geometry SOP network is missing")
+
+    usd_import = sopnet.node("import_usd")
+    if usd_import is None:
+        raise RuntimeError("Template network is missing the import_usd node")
+    usd_import.parm("filepath1").set(usd_path.as_posix())  # type: ignore[union-attr]
+
+    polyreduce = sopnet.node("polyreduce1")
+    if polyreduce:
+        polyreduce.setDisplayFlag(True)  # type: ignore[attr-defined]
+        polyreduce.setRenderFlag(True)  # type: ignore[attr-defined]
+        try:
+            polyreduce.setCurrent(True, clear_all_selected=False)
+        except hou.OperationFailed:
+            log.debug("Unable to set polyreduce node current; continuing")
+
+
+def build_component_package(
+    *,
+    hip_path: Path,
+    usd_path: Path,
+    export_dir: Path,
+    component_name: str,
+    asset_name: str | None = None,
+    root_prim: str | None = None,
+    clean_export: bool = False,
+) -> None:
+    usd_path = usd_path.resolve()
+    if not usd_path.exists():
+        raise FileNotFoundError(f"USD file not found: {usd_path}")
+
+    hip_path = hip_path.resolve()
+    hip_path.parent.mkdir(parents=True, exist_ok=True)
+
+    export_dir = export_dir.resolve()
+    if clean_export and export_dir.exists():
+        log.info("Cleaning existing export directory: %s", export_dir)
+        shutil.rmtree(export_dir)
+    export_dir.mkdir(parents=True, exist_ok=True)
+
+    log.info("Initializing new Houdini session at %s", hip_path)
+    hou.hipFile.clear(suppress_save_prompt=True)
+    hou.hipFile.save(str(hip_path))
+    hou.setContextOption("ASSET", asset_name or component_name)
+
+    stage = _prepare_stage()
+
+    log.info("Building Bobo component network")
+    component_out = stage.createNode("componentoutput", node_name="COMPONENT_OUT")
+    component_out.setColor(hou.Color((0.616, 0.871, 0.769)))
+
+    geo = nodelayouts.bobo_componentgeometry({}, parent=stage)
+    cmat = nodelayouts.lnd_componentmaterial({}, parent=stage)
+    lib = stage.createNode("dbclark::main::Bobo_MatLib")
+    cnf = stage.createNode("sdm223::lnd_componentconfig")
+    ldv = stage.createNode("sdm223::dev::LnD_Lookdev")
+    env = stage.createNode("fetch")
+
+    component_out.setInput(0, cnf)
+    component_out.setInput(1, env)
+    cnf.setInput(0, cmat)
+    cmat.setInput(0, geo)
+    cmat.setInput(1, lib)
+    ldv.setInput(0, component_out)
+
+    env.parm("loppath").set(f"../{ldv.name()}/OUT_ENV")  # type: ignore[union-attr]
+
+    component_out.moveToGoodPosition()
+    for node in (geo, cmat, lib, cnf, ldv, env):
+        node.moveToGoodPosition()
+
+    component_out.setDisplayFlag(True)  # type: ignore[attr-defined]
+    geo.setDisplayFlag(True)  # type: ignore[attr-defined]
+
+    _configure_component_geometry(geo, usd_path)  # type: ignore[arg-type]
+
+    component_out.setCurrent(True, clear_all_selected=True)
+
+    root_name = root_prim or component_name
+    _set_parm(component_out, "filename", component_name)
+    _set_parm(component_out, "lopoutput", '$HIP/export/`chs("filename")`')
+    _set_parm(component_out, "rootprim", f"/{root_name}")
+    _set_parm(component_out, "localize", False)
+    _set_parm(component_out, "thumbnailmode", 2)
+    _set_parm(component_out, "renderer", "RenderMan RIS")
+    _set_parm(component_out, "thumbnailscenesource", 1)
+    _set_parm(component_out, "thumbnailinputcamera", "/lookdev/cam")
+
+    log.info("Saving component package to %s", export_dir)
+    if not component_out.saveToDisk():  # type: ignore[attr-defined]
+        raise RuntimeError("Component Output node failed to save to disk")
+
+    hou.hipFile.save()
+    log.info("Component package build complete")
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build Houdini component package from Maya export"
+    )
+    parser.add_argument("--hip-path", required=True, help="Destination .hipnc path")
+    parser.add_argument(
+        "--usd-path", required=True, help="Source USD file exported from Maya"
+    )
+    parser.add_argument(
+        "--export-dir",
+        required=True,
+        help="Directory where component USD layers will be written",
+    )
+    parser.add_argument(
+        "--component-name",
+        required=True,
+        help="Component identifier used for filenames and root prim",
+    )
+    parser.add_argument(
+        "--root-prim", help="Optional override for the component root prim name"
+    )
+    parser.add_argument("--variant", help="Geometry variant name (for logging only)")
+    parser.add_argument("--log-level", default="INFO", help="Python logging level")
+    parser.add_argument(
+        "--clean-export",
+        action="store_true",
+        help="Remove the export directory before writing new files",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    _configure_logging(args.log_level)
+
+    component_name = args.component_name
+    if args.variant:
+        log.info("Processing variant: %s", args.variant)
+
+    try:
+        build_component_package(
+            hip_path=Path(args.hip_path),
+            usd_path=Path(args.usd_path),
+            export_dir=Path(args.export_dir),
+            component_name=component_name,
+            root_prim=args.root_prim,
+            clean_export=args.clean_export,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.exception("Failed to build component package: %s", exc)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline/pipe/h/assetbuilder.py
+++ b/pipeline/pipe/h/assetbuilder.py
@@ -1,3 +1,5 @@
+"""Build Houdini component packages for the Bobo asset pipeline."""
+
 from __future__ import annotations
 
 import argparse
@@ -14,6 +16,7 @@ log = logging.getLogger(__name__)
 
 
 def _configure_logging(level: str) -> None:
+    """Normalize CLI logging so build output stays predictable."""
     level_name = level.upper()
     numeric_level = getattr(logging, level_name, None)
     if not isinstance(numeric_level, int):
@@ -25,6 +28,7 @@ def _configure_logging(level: str) -> None:
 
 
 def _set_parm(node: hou.Node, name: str, value) -> None:
+    """Set a Houdini parameter and warn if templates drift from expectations."""
     parm = node.parm(name)
     if parm is None:
         log.warning("Parameter %s missing on %s", name, node.path())
@@ -33,12 +37,12 @@ def _set_parm(node: hou.Node, name: str, value) -> None:
 
 
 def _prepare_stage() -> hou.Node:
+    """Clear /stage so every package build starts from a clean LOP network."""
     stage = hou.node("/stage")
     if stage is None:
         raise RuntimeError(
             "Could not locate /stage context in the current Houdini session"
         )
-    # type: ignore[union-attr]
     for child in stage.children():
         try:
             child.destroy()
@@ -51,6 +55,7 @@ def _prepare_stage() -> hou.Node:
 
 
 def _configure_component_geometry(geo_node: hou.LopNode, usd_path: Path) -> None:
+    """Wire the imported USD into the component SOP net and promote preview nodes."""
     sopnet = geo_node.node("./sopnet/geo")
     if sopnet is None:
         raise RuntimeError("Component Geometry SOP network is missing")
@@ -58,16 +63,55 @@ def _configure_component_geometry(geo_node: hou.LopNode, usd_path: Path) -> None
     usd_import = sopnet.node("import_usd")
     if usd_import is None:
         raise RuntimeError("Template network is missing the import_usd node")
-    usd_import.parm("filepath1").set(usd_path.as_posix())  # type: ignore[union-attr]
+    _set_parm(usd_import, "filepath1", usd_path.as_posix())
 
     polyreduce = sopnet.node("polyreduce1")
     if polyreduce:
-        polyreduce.setDisplayFlag(True)  # type: ignore[attr-defined]
-        polyreduce.setRenderFlag(True)  # type: ignore[attr-defined]
+        # Keep the proxy reduction visible so artists land on performant geometry.
+        if hasattr(polyreduce, "setDisplayFlag"):
+            polyreduce.setDisplayFlag(True)
+        if hasattr(polyreduce, "setRenderFlag"):
+            polyreduce.setRenderFlag(True)
         try:
             polyreduce.setCurrent(True, clear_all_selected=False)
         except hou.OperationFailed:
             log.debug("Unable to set polyreduce node current; continuing")
+
+
+def _execute_component_output(node: hou.Node) -> None:
+    """Trigger the componentoutput node across Houdini versions."""
+    previous_errors = tuple(node.errors())
+    executed = False
+
+    if isinstance(node, hou.RopNode):
+        node.render()
+        executed = True
+    else:
+        save_to_disk = getattr(node, "saveToDisk", None)
+        if callable(save_to_disk):
+            if not save_to_disk():
+                raise RuntimeError("Component Output node failed to save to disk")
+            executed = True
+        else:
+            for button in ("execute", "render", "renderbutton"):
+                parm = node.parm(button)
+                if parm is None:
+                    continue
+                parm.pressButton()
+                executed = True
+                break
+
+    if not executed:
+        raise RuntimeError(
+            f"Component Output node {node.path()} has no supported execution parameter"
+        )
+
+    new_errors = [err for err in node.errors() if err not in previous_errors]
+    if new_errors:
+        joined = "; ".join(new_errors)
+        raise RuntimeError(
+            f"Component Output node {node.path()} reported errors: {joined}"
+        )
 
 
 def build_component_package(
@@ -80,6 +124,11 @@ def build_component_package(
     root_prim: str | None = None,
     clean_export: bool = False,
 ) -> None:
+    """Generate a Houdini component package network and write the exported USD.
+
+    asset_name populates the ASSET context option so downstream tools can link
+    the session back to the ShotGrid entity that initiated the publish.
+    """
     usd_path = usd_path.resolve()
     if not usd_path.exists():
         raise FileNotFoundError(f"USD file not found: {usd_path}")
@@ -104,7 +153,10 @@ def build_component_package(
     component_out = stage.createNode("componentoutput", node_name="COMPONENT_OUT")
     component_out.setColor(hou.Color((0.616, 0.871, 0.769)))
 
-    geo = nodelayouts.bobo_componentgeometry({}, parent=stage)
+    geo_node = nodelayouts.bobo_componentgeometry({}, parent=stage)
+    if not isinstance(geo_node, hou.LopNode):
+        raise RuntimeError("Component geometry network must be created inside LOPs")
+    geo = geo_node
     cmat = nodelayouts.lnd_componentmaterial({}, parent=stage)
     lib = stage.createNode("dbclark::main::Bobo_MatLib")
     cnf = stage.createNode("sdm223::lnd_componentconfig")
@@ -118,16 +170,18 @@ def build_component_package(
     cmat.setInput(1, lib)
     ldv.setInput(0, component_out)
 
-    env.parm("loppath").set(f"../{ldv.name()}/OUT_ENV")  # type: ignore[union-attr]
+    _set_parm(env, "loppath", f"../{ldv.name()}/OUT_ENV")
 
     component_out.moveToGoodPosition()
     for node in (geo, cmat, lib, cnf, ldv, env):
         node.moveToGoodPosition()
 
-    component_out.setDisplayFlag(True)  # type: ignore[attr-defined]
-    geo.setDisplayFlag(True)  # type: ignore[attr-defined]
+    if hasattr(component_out, "setDisplayFlag"):
+        component_out.setDisplayFlag(True)
+    if hasattr(geo, "setDisplayFlag"):
+        geo.setDisplayFlag(True)
 
-    _configure_component_geometry(geo, usd_path)  # type: ignore[arg-type]
+    _configure_component_geometry(geo, usd_path)
 
     component_out.setCurrent(True, clear_all_selected=True)
 
@@ -142,14 +196,14 @@ def build_component_package(
     _set_parm(component_out, "thumbnailinputcamera", "/lookdev/cam")
 
     log.info("Saving component package to %s", export_dir)
-    if not component_out.saveToDisk():  # type: ignore[attr-defined]
-        raise RuntimeError("Component Output node failed to save to disk")
+    _execute_component_output(component_out)
 
     hou.hipFile.save()
     log.info("Component package build complete")
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Translate CLI arguments into configuration for the asset builder."""
     parser = argparse.ArgumentParser(
         description="Build Houdini component package from Maya export"
     )
@@ -168,6 +222,10 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help="Component identifier used for filenames and root prim",
     )
     parser.add_argument(
+        "--asset-name",
+        help="Name stored on the ASSET context option for downstream tools",
+    )
+    parser.add_argument(
         "--root-prim", help="Optional override for the component root prim name"
     )
     parser.add_argument("--variant", help="Geometry variant name (for logging only)")
@@ -181,6 +239,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Entrypoint for command-line execution."""
     args = _parse_args(argv or sys.argv[1:])
     _configure_logging(args.log_level)
 
@@ -194,6 +253,7 @@ def main(argv: list[str] | None = None) -> int:
             usd_path=Path(args.usd_path),
             export_dir=Path(args.export_dir),
             component_name=component_name,
+            asset_name=args.asset_name,
             root_prim=args.root_prim,
             clean_export=args.clean_export,
         )

--- a/pipeline/pipe/m/publish/asset.py
+++ b/pipeline/pipe/m/publish/asset.py
@@ -4,6 +4,7 @@ import hmac
 import json
 import logging
 import os
+import subprocess
 from hashlib import sha1
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -23,9 +24,10 @@ from pipe.glui.dialogs import (
     MessageDialogCustomButtons,
 )
 from pipe.struct.db import Asset, SGEntity
-from shared.util import get_production_path
-from env import PIPEBOT_SECRET, PIPEBOT_URL
+from shared.util import get_pipe_path, get_production_path
+from env import Executables, PIPEBOT_SECRET, PIPEBOT_URL
 
+from software.houdini.dcc import HoudiniDCC
 from .publisher import Publisher
 
 try:
@@ -35,6 +37,15 @@ except TypeError:
     MCUI = object
 
 log = logging.getLogger(__name__)
+
+
+ASSET_BUILDER_SCRIPT = get_pipe_path() / "pipe/h/assetbuilder.py"
+
+
+class HoudiniBuildError(RuntimeError):
+    """Raised when the Houdini asset build fails"""
+
+    pass
 
 
 class PublishAssetDialog(FilteredListDialog):
@@ -118,9 +129,43 @@ class PublishAssetDialog(FilteredListDialog):
 
 class AssetPublisher(Publisher):
     _override: bool
+    _geo_variant: str
+    _is_substance_only: bool
+    _component_export_dir: Path | None
+    _component_hip_path: Path | None
+    _component_basename: str | None
+    _asset_pipe_name: str | None
+    _houdini_error: str | None
 
     def __init__(self) -> None:
         super().__init__(PublishAssetDialog)
+        self._geo_variant = "main"
+        self._is_substance_only = False
+        self._component_export_dir = None
+        self._component_hip_path = None
+        self._component_basename = None
+        self._asset_pipe_name = None
+        self._houdini_error = None
+
+    @staticmethod
+    def _compute_component_basename(
+        asset: Asset, variant: str, is_substance: bool
+    ) -> tuple[str, str]:
+        pipe_name = (asset.name or "").strip()
+        if not pipe_name or pipe_name.lower() == "none":
+            pipe_name = (asset.disp_name or "").strip()
+        if not pipe_name and asset.path:
+            pipe_name = Path(asset.path).name
+        if not pipe_name:
+            pipe_name = "asset"
+
+        base_name = pipe_name
+        if variant and variant != "main":
+            base_name = f"{base_name}_{variant}"
+        if is_substance:
+            base_name = f"{base_name}_SUBSTANCE"
+
+        return pipe_name, base_name
 
     def _prepublish(self) -> bool:
         checker = ModelChecker.get()
@@ -180,21 +225,25 @@ class AssetPublisher(Publisher):
             error.exec_()
             return None
 
+        self._geo_variant = variant_name
+        self._is_substance_only = dialog.is_substance_only
+        self._component_export_dir = None
+        self._component_hip_path = None
+        self._asset_pipe_name = None
+        self._houdini_error = None
+
         if variant_name not in asset.geometry_variants:
             asset.geometry_variants.add(variant_name)
             log.info(f"Updating new geo variant: {variant_name}")
             self._conn.update_asset(asset)
 
-        return (
-            get_production_path()
-            / asset.path
-            / (
-                asset.name
-                + (f"_{variant_name}" if variant_name != "main" else "")
-                + ("_SUBSTANCE" if dialog.is_substance_only else "")
-                + ".usd"
-            )
+        pipe_name, basename = self._compute_component_basename(
+            asset, variant_name, dialog.is_substance_only
         )
+        publish_dir = get_production_path() / asset.path
+        self._asset_pipe_name = pipe_name
+        self._component_basename = basename
+        return publish_dir / f"{basename}.usd"
 
     def _presave(self) -> bool:
         # notify webhook of override
@@ -222,6 +271,145 @@ class AssetPublisher(Publisher):
         return {
             "shadingMode": "useRegistry",
         }
+
+    def _postpublish(self) -> None:
+        if self._is_substance_only:
+            log.info("Skipping Houdini component publish for substance-only export")
+            return
+
+        asset = cast(Asset, self._entity)
+        try:
+            self._run_houdini_asset_builder(asset)
+        except HoudiniBuildError as exc:
+            self._houdini_error = str(exc)
+            log.error("Houdini asset build failed: %s", exc, exc_info=True)
+            MessageDialog(
+                self._window,
+                "Houdini component publish failed. Please review the Script Editor for details.",
+                "Houdini Export Failed",
+            ).exec_()
+        else:
+            self._houdini_error = None
+
+    def _run_houdini_asset_builder(self, asset: Asset) -> None:
+        publish_path = getattr(self, "_publish_path", None)
+        if publish_path is None:
+            raise HoudiniBuildError(
+                "Publish path is undefined; cannot build Houdini component package."
+            )
+
+        publish_path = Path(publish_path)
+        component_name = self._component_basename or publish_path.stem
+        publish_dir = publish_path.parent
+        export_dir = publish_dir / "export"
+        hip_path = publish_dir / f"{component_name}.hipnc"
+
+        self._component_export_dir = export_dir
+        self._component_hip_path = hip_path
+
+        if not ASSET_BUILDER_SCRIPT.exists():
+            raise HoudiniBuildError(
+                f"Unable to locate Houdini asset builder script: {ASSET_BUILDER_SCRIPT}"
+            )
+
+        if not Executables.hython.exists():
+            raise HoudiniBuildError(
+                f"Houdini executable not found at {Executables.hython}"
+            )
+
+        asset_pipe_name = (
+            self._asset_pipe_name
+            or (asset.name or "").strip()
+            or (asset.disp_name or "").strip()
+        )
+        if not asset_pipe_name and asset.path:
+            asset_pipe_name = Path(asset.path).name
+        if not asset_pipe_name:
+            asset_pipe_name = component_name
+
+        command = [
+            str(Executables.hython),
+            "-m",
+            "pipe.h.assetbuilder",
+            "--hip-path",
+            str(hip_path),
+            "--usd-path",
+            str(publish_path),
+            "--export-dir",
+            str(export_dir),
+            "--component-name",
+            component_name,
+            "--asset-name",
+            asset_pipe_name,
+            "--variant",
+            self._geo_variant,
+            "--clean-export",
+        ]
+
+        if asset_pipe_name and asset_pipe_name != component_name:
+            command.extend(["--root-prim", asset_pipe_name])
+
+        dcc = HoudiniDCC(is_python_shell=True)
+        env = dcc._get_env_vars()
+        env["PIPE_LOG_LEVEL"] = str(log.getEffectiveLevel())
+
+        log.info("Running Houdini asset builder for %s", component_name)
+        try:
+            result = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+        except FileNotFoundError as exc:
+            raise HoudiniBuildError(
+                "Failed to execute hython; verify Houdini is installed."
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            stdout = exc.stdout or ""
+            stderr = exc.stderr or ""
+            if stdout:
+                log.error("Houdini asset builder stdout:\n%s", stdout)
+            if stderr:
+                log.error("Houdini asset builder stderr:\n%s", stderr)
+            raise HoudiniBuildError(
+                f"Houdini component publish failed with exit code {exc.returncode}"
+            ) from exc
+        else:
+            if result.stdout:
+                log.debug("Houdini asset builder stdout:\n%s", result.stdout)
+            if result.stderr:
+                log.debug("Houdini asset builder stderr:\n%s", result.stderr)
+
+        if not hip_path.exists():
+            raise HoudiniBuildError(
+                f"Houdini component build did not produce hip file at {hip_path}"
+            )
+        if not export_dir.exists():
+            raise HoudiniBuildError(
+                f"Houdini component build did not create export directory at {export_dir}"
+            )
+
+    def _get_confirm_message(self) -> str:
+        message = super()._get_confirm_message()
+        if self._is_substance_only:
+            return message
+
+        if self._houdini_error:
+            return (
+                f"{message}\n\nHoudini component publish failed: {self._houdini_error}"
+            )
+
+        extras: list[str] = []
+        if self._component_hip_path:
+            extras.append(f"Houdini scene: {self._component_hip_path}")
+        if self._component_export_dir:
+            extras.append(f"Houdini exports: {self._component_export_dir}")
+        if extras:
+            message = f"{message}\n\n" + "\n".join(extras)
+
+        return message
 
 
 class ModelChecker(MCUI):


### PR DESCRIPTION
Previously, after exporting an asset from maya, if you wanted to use it in houdini, you had to re-export it in houdini by following these steps:

1. Open the asset in houdini from bobaris
2. add a bobo component builder
3. go into the component geometry node at the top, and import the correct asset in the USD import node at the top
4. view the polyreduce node
5. go back to the stage, and go to the component output node, and hit save to disk

It would be pretty neat if artists didn't have to double publish, and Charvey agrees!. :cowboy_hat_face: :

This pull request introduces a shiny new Houdini asset builder and wires it into the Maya publish asset step. It is built as a CLI tool so that maya can run it through `hython` (`hython -m pipe.h.assetbuilder`). This is the jimmy rig solution I came up with. If you know a better way to do call `hython` from Maya, let me know. But it works! Yipee!

It does need testing! I suspect bush and tree assets won't work correctly right now. But error handling and reporting is robust. If it runs into any issues, it will tell the user, then revert to the old functionality. Worst case scenario, they just re-publish the houdini package like they always have.