### PR TITLE
Remove unnessisary file parameter

### DIFF
--- a/pipeline/pipe/h/assetbuilder.py
+++ b/pipeline/pipe/h/assetbuilder.py
@@ -186,7 +186,6 @@ def build_component_package(
     component_out.setCurrent(True, clear_all_selected=True)
 
     root_name = root_prim or component_name
-    _set_parm(component_out, "filename", component_name)
     _set_parm(component_out, "lopoutput", '$HIP/export/`chs("filename")`')
     _set_parm(component_out, "rootprim", f"/{root_name}")
     _set_parm(component_out, "localize", False)


### PR DESCRIPTION
Publishing from Houdini would produce USD files missing the actual `.usd` extension. Oops. It works correctly now. Other changes will come soon. This is a hotfix