### PR TITLE
Abstract USD shot camera location fetching

### DIFF
--- a/pipeline/pipe/m/playblast/anim.py
+++ b/pipeline/pipe/m/playblast/anim.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
 import logging
-import maya.cmds as mc
-
 from datetime import datetime
 from typing import TYPE_CHECKING
-from Qt.QtWidgets import QComboBox, QGridLayout, QLabel, QSpinBox, QWidget
+
+import maya.cmds as mc
+from env_sg import DB_Config
 from Qt.QtCore import QRegExp
 from Qt.QtGui import QRegExpValidator
+from Qt.QtWidgets import QComboBox, QGridLayout, QLabel, QSpinBox, QWidget
+from shared.util import get_edit_path
 
 from pipe.db import DB
-from pipe.util import checkbox_callback_helper, Playblaster
-from shared.util import get_edit_path
-from env_sg import DB_Config
+from pipe.m.shotfile.anim import _find_usd_shotcam
+from pipe.util import Playblaster, checkbox_callback_helper
 
 from .struct import (
     HudDefinition,
@@ -129,7 +130,7 @@ class AnimPlayblastDialog(PlayblastDialog):
             sg_config = next(c for c in self._shot_dialog_configs if c.id == self.SG_ID)
             shots.append(
                 MShotPlayblastConfig(
-                    camera="|__mayaUsd__|shotCamParent|shotCam",
+                    camera=self._get_shot_camera_path(),
                     shot=self._shot,
                     paths=self.save_locations_to_paths(
                         self.SG_ID,
@@ -193,3 +194,11 @@ class AnimPlayblastDialog(PlayblastDialog):
             shots=shots,
             ssao=self.use_ssao,
         )
+
+    def _get_shot_camera_path(self) -> str | None:
+        """Resolve the USD shot camera in Maya, supporting both legacy and current hierarchies."""
+        cam = _find_usd_shotcam()
+        if cam:
+            return cam
+        log.warning("No USD shot camera found; falling back to legacy path.")
+        return "|__mayaUsd__|shotCamParent|shotCam"

--- a/pipeline/pipe/m/shotfile/anim.py
+++ b/pipeline/pipe/m/shotfile/anim.py
@@ -1,14 +1,51 @@
 import logging
-import maya.cmds as mc
-
 from pathlib import Path
-from pxr import Usd, UsdGeom
+from typing import Optional
 
+import maya.cmds as mc
+from pxr import Usd, UsdGeom
 from shared.util import get_production_path
 
 from .shotfile_manager import MShotFileManager
 
 log = logging.getLogger(__name__)
+
+
+def _find_usd_shotcam() -> Optional[str]:
+    """Locate the shot camera brought in via MayaUSD"""
+    # look for any transform named shotCam under the mayaUsd proxy (__mayaUsd__ in its path)
+    candidates = [
+        path
+        for path in (mc.ls("*shotCam", type="transform", long=True) or [])
+        if "__mayaUsd__" in path.split("|")
+    ]
+    if not candidates:
+        return None
+    # prefer shortest (legacy: |__mayaUsd__|shotCamParent|shotCam), otherwise deterministic
+    candidates.sort(key=len)
+    return candidates[0]
+
+
+def _lock_camera_chain(cam_transform: str) -> None:
+    """Lock transforms on the shot camera and every parent to prevent accidental edits."""
+    parts = cam_transform.split("|")
+    current = ""
+    for part in parts[1:]:  # skip leading empty string
+        current = f"{current}|{part}"
+        if not mc.objExists(current):
+            continue
+        for attr in ("tx", "ty", "tz", "rx", "ry", "rz", "sx", "sy", "sz"):
+            try:
+                mc.setAttr(
+                    f"{current}.{attr}", lock=True, keyable=False, channelBox=False
+                )
+            except Exception:
+                pass
+    for shape in mc.listRelatives(cam_transform, shapes=True, fullPath=True) or []:
+        try:
+            mc.camera(shape, edit=True, lockTransform=True)
+        except Exception:
+            pass
 
 
 class MAnimShotFileManager(MShotFileManager):
@@ -31,9 +68,20 @@ class MAnimShotFileManager(MShotFileManager):
             mc.mayaUsdEditAsMaya(
                 cls.get_stage_shape() + "," + str(camera_prim.GetPrimPath())
             )
-            camera_shape = mc.listRelatives(CAM_NAME, fullPath=True, shapes=True)[0]
-            mc.lookThru(CAM_NAME)
-            mc.camera(camera_shape, edit=True, lockTransform=True)
+            cam_path = _find_usd_shotcam()
+            if cam_path:
+                _lock_camera_chain(cam_path)
+                mc.lookThru(cam_path)
+            else:
+                # fallback to legacy name if discovery fails
+                try:
+                    camera_shape = mc.listRelatives(
+                        CAM_NAME, fullPath=True, shapes=True
+                    )[0]
+                    mc.camera(camera_shape, edit=True, lockTransform=True)
+                    mc.lookThru(CAM_NAME)
+                except Exception:
+                    mc.warning("Could not locate USD shot camera in Maya scene.")
 
     def _get_subpath(self) -> str:
         return "anim"


### PR DESCRIPTION
This pull request improves the handling and robustness of USD shot camera discovery and locking in Maya animation playblast and shotfile workflows. It's more than should be needed, but I want better error reporting for these types of problems. this pull request will resolve Issue #78.

 The main changes introduce a utility for reliably locating the USD shot camera, update camera path resolution logic to support both the old and current hierarchies, and ensure camera transforms are locked to prevent accidental edits.
 
 Note that the current shotcam path includes `LnD`, which we may want to make `bobo` at some point. For now, this works, and I am satisfied.

**USD Shot Camera Discovery and Locking Enhancements:**

* Added `_find_usd_shotcam` utility function in `shotfile/anim.py` to reliably locate the USD shot camera in Maya.
* Introduced `_lock_camera_chain` function to lock transforms on the shot camera and its parent nodes, preventing accidental edits.
* Updated `run_on_open` in `MAnimShotFileManager` to use the new camera discovery and locking utilities, with a fallback to legacy functionality if discovery fails.

**Playblast Configuration Improvements:**

* Refactored playblast camera path resolution in `anim.py` to use `_get_shot_camera_path`, which leverages the new USD shot camera discovery logic and provides a fallback for legacy scenes.