### PR TITLE
FIX THE MULTI RIG ISSUE FOR GOOOOOOOOOOD

### DIFF
--- a/pipeline/pipe/m/publish/usdchaser.py
+++ b/pipeline/pipe/m/publish/usdchaser.py
@@ -524,8 +524,6 @@ class ExportChaser(mayaUsdLib.ExportChaser):
                 relative_path_str = None
                 try:
                     asset = conn.get_asset_by_attr("name", base_name)
-                    if base_name != name:
-                        add_variant_to_model(asset, name)
 
                     assert asset.path is not None
                     rig_path = str(asset.path).replace("\\", "/") + "/usd/main.usd"
@@ -550,6 +548,28 @@ class ExportChaser(mayaUsdLib.ExportChaser):
                         f"    relative_path={relative_path_str} root_layer={root_layer.realPath}"
                     )
                     print(traceback.format_exc())
+                if name != base_name and relative_path_str:
+                    # Create a concrete rig instance for this namespace so the
+                    # class-based clips can bind to a real prim.
+                    character_parent = Sdf.CreatePrimInLayer(
+                        root_layer, Sdf.Path("/character")
+                    )
+                    character_parent.specifier = Sdf.SpecifierOver
+
+                    instance_prim_path = Sdf.Path(f"/character/{name}")
+                    instance_prim_spec = Sdf.CreatePrimInLayer(
+                        root_layer, instance_prim_path
+                    )
+                    instance_prim_spec.specifier = Sdf.SpecifierDef
+
+                    rig_prim_path = Sdf.Path(f"/character/{base_name}")
+                    instance_reference = Sdf.Reference(relative_path_str, rig_prim_path)
+                    instance_prim_spec.referenceList.appendedItems = [
+                        instance_reference
+                    ]
+                    instance_prim_spec.inheritPathList.prependedItems = [
+                        Sdf.Path(f"/__class__/character/{name}")
+                    ]
 
         elif self._chaser_args.mode == ChaserMode.CHAR:
             scale_down_geo(self._stage)


### PR DESCRIPTION
RAAAAAH WE BALLL

I changed the animation chaser so each duplicated character namespace now gets its own real rig prim in the shot layer. ANIM export still writes class prims under `/__class__/character/<name>` (the clip data), but it also author‑defines `/character/<name>` and makes it reference the base rig prim (`/character/<name>`) while inheriting the matching class. This makes every bee an actual instance in the composed stage.

It works on B_070! Wohoo! But I need to touch basis with Tiffany to make sure I am not nuking what she needs for CFX. I don't think I am (in fact her job would be easier based on my understanding) but she'll know best
