### PR TITLE
HOTFIX: fix anim publish prim namespace removal 

### DIFF
--- a/pipeline/pipe/m/publish/usdchaser.py
+++ b/pipeline/pipe/m/publish/usdchaser.py
@@ -244,7 +244,8 @@ def remove_namespace(
             return
         dag_path = path_dag_map.get(path)
         if dag_path:
-            node = MFnDependencyNode(dag_path.node())
+            # By default the Maya export gives the USD meshes the names of their maya transform counterparts.
+            node = MFnDependencyNode(dag_path.transform())
             # Still have to manually strip the namespace, but at least it's with a colon which maya ONLY allows for use as a namespace delimiter.
             name = node.name().rsplit(":", 1)[-1]
             edit.Add(Sdf.NamespaceEdit.Rename(path, name))


### PR DESCRIPTION
When I switched out the ExportChaser's logic for removing the namespace from prims I overlooked that the MDagPath -> Sdf.Path Mapping was from the Maya Shape node to the Prim for meshes, but that the with the default USD export, maya assigned the prim the name of the transform rather than the shape. 

This broke the USD composition of the exported animation, since all meshes had their shape name rather than transform name. This should fix it.